### PR TITLE
feat: Implement search by genre with Project Gutenberg API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -18,14 +18,20 @@ const APP_TITLE = "Biblioteca Pubblica per Bambini";
  * is now encapsulated in the `useBooks` custom hook.
  */
 function App() {
+  const [searchType, setSearchType] = useState('title_author');
   // Use the custom hook to get the state and functions needed by the component.
   // This keeps the App component clean and focused on the UI.
-  const { searchQuery, setSearchQuery, filteredBooks } = useBooks();
+  const { searchQuery, setSearchQuery, filteredBooks, loading } = useBooks(searchType);
 
   // The event handler for the search input now simply calls the state setter
   // provided by the `useBooks` hook.
   const handleSearchChange = (event) => {
     setSearchQuery(event.target.value);
+  };
+
+  const handleSearchTypeChange = (event) => {
+    setSearchType(event.target.value);
+    setSearchQuery(''); // Reset search query when changing search type
   };
 
   return (
@@ -47,10 +53,12 @@ function App() {
         <SearchBar
           searchQuery={searchQuery}
           onSearchChange={handleSearchChange}
+          searchType={searchType}
+          onSearchTypeChange={handleSearchTypeChange}
         />
 
         {/* Book List Component */}
-        <BookList books={filteredBooks} />
+        <BookList books={filteredBooks} loading={loading} />
       </Container>
     </>
   );

--- a/src/BookList.jsx
+++ b/src/BookList.jsx
@@ -5,6 +5,7 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 
 /**
  * BookList Component
@@ -12,12 +13,23 @@ import Box from '@mui/material/Box';
  * Renders a list of books. Each book is clickable and opens a URL in a new tab.
  * @param {object} props - The component props.
  * @param {Array<object>} props.books - The array of book objects to display.
+ * @param {boolean} props.loading - Whether the books are currently being loaded.
  */
-function BookList({ books }) {
+function BookList({ books, loading }) {
 
   const handleBookClick = (pdfUrl) => {
-    window.open(pdfUrl, '_blank', 'noopener,noreferrer');
+    if (pdfUrl) {
+      window.open(pdfUrl, '_blank', 'noopener,noreferrer');
+    }
   };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
 
   if (books.length === 0) {
     return (
@@ -32,7 +44,7 @@ function BookList({ books }) {
       <List>
         {books.map((book) => (
           <ListItem key={book.title} disablePadding>
-            <ListItemButton onClick={() => handleBookClick(book.pdfUrl)}>
+            <ListItemButton onClick={() => handleBookClick(book.pdfUrl)} disabled={!book.pdfUrl}>
               <ListItemText
                 primary={book.title}
                 secondary={`${book.author} (${book.year})`}

--- a/src/SearchBar.jsx
+++ b/src/SearchBar.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
 
 /**
  * SearchBar Component
@@ -9,16 +13,31 @@ import Box from '@mui/material/Box';
  * @param {object} props - The component props.
  * @param {string} props.searchQuery - The current value of the search input.
  * @param {function} props.onSearchChange - The function to call when the search input changes.
+ * @param {string} props.searchType - The current search type.
+ * @param {function} props.onSearchTypeChange - The function to call when the search type changes.
  */
-function SearchBar({ searchQuery, onSearchChange }) {
+function SearchBar({ searchQuery, onSearchChange, searchType, onSearchTypeChange }) {
   return (
-    <Box sx={{ marginY: 4, display: 'flex', justifyContent: 'center' }}>
+    <Box sx={{ marginY: 4, display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2 }}>
+      <FormControl sx={{ minWidth: 120 }}>
+        <InputLabel id="search-type-label">Cerca per</InputLabel>
+        <Select
+          labelId="search-type-label"
+          id="search-type-select"
+          value={searchType}
+          label="Cerca per"
+          onChange={onSearchTypeChange}
+        >
+          <MenuItem value="title_author">Titolo/Autore</MenuItem>
+          <MenuItem value="genre">Genere</MenuItem>
+        </Select>
+      </FormControl>
       <TextField
-        label="Cerca un libro per titolo o autore..."
+        label="Cerca un libro..."
         variant="outlined"
         value={searchQuery}
         onChange={onSearchChange}
-        sx={{ width: '80%', maxWidth: '600px' }}
+        sx={{ width: '60%', maxWidth: '500px' }}
       />
     </Box>
   );


### PR DESCRIPTION
This commit refactors the book search functionality to use the Gutendex API, allowing you to search for books by title/author or by genre.

Key changes:
- Replaced the static `books.json` data source with API calls to `gutendex.com`.
- Added a dropdown menu to the search bar to select the search type (Title/Author or Genre).
- Updated the `useBooks` custom hook to handle API requests, including debouncing and a loading state.
- The `BookList` component now displays a loading indicator while fetching data.